### PR TITLE
fix: fix buildscpec_deploytoecs 

### DIFF
--- a/.aws/ci/buildspec_deploytoecs.yml
+++ b/.aws/ci/buildspec_deploytoecs.yml
@@ -1,7 +1,7 @@
 version: 0.2
 
 phases:
-  deploy:
+  install:
     runtime-versions:
       docker: 19
     commands:

--- a/template.yml
+++ b/template.yml
@@ -168,7 +168,5 @@ Outputs:
   LoadBalancerUrl:
     Description: Application DNS
     Value: !GetAtt LoadBalancer.DNSName
-
-  Listener:
-    Description: A reference to a port 80 listener
-    Value: !Ref HTTPLoadBalancerListener
+    Export:
+      Name: !Sub ${AWS::StackName}-dns


### PR DESCRIPTION
- Fix  buildscpec_deploytoecs install phase name
- Add new output export to AWS cloudformation template